### PR TITLE
Updated Postman_api path

### DIFF
--- a/postman/api.ed-fi.org-v6.1.postman_environment.json
+++ b/postman/api.ed-fi.org-v6.1.postman_environment.json
@@ -1,33 +1,63 @@
 {
-	"id": "1688785c-6ecc-486c-b67d-bd0da852e20a",
+	"id": "4490bd4b-3593-42ff-9f1e-08ae37bf836d",
 	"name": "api.ed-fi.org/v6.1",
 	"values": [
 		{
 			"key": "baseUrl",
-			"value": "https://api.ed-fi.org/v6.1/api",
+			"value": "https://certification2.ed-fi.org/v6.1/api",
 			"type": "default",
 			"enabled": true
 		},
 		{
-			"key": "resourcesBaseUrl",
-			"value": "{{baseUrl}}/data/v3",
+			"key": "resourceBaseUrl",
+			"value": "https://certification2.ed-fi.org/v6.1/api/data/v3",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "edFiClientId",
-			"value": "RvcohKz9zHI4",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "edFiClientSecret",
-			"value": "E1iEFusaNf81xzCxwHfbolkC",
+			"value": "",
 			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "certToken",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "s1CalendarId",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "s1CalendarDateId",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "s1GradingPeriodId",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "s1SessionId",
+			"value": "",
+			"type": "any",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-03-11T21:16:44.776Z",
-	"_postman_exported_using": "Postman/10.24.1"
+	"_postman_exported_at": "2025-01-08T21:02:50.093Z",
+	"_postman_exported_using": "Postman/11.23.3"
 }

--- a/postman/api.ed-fi.org-v6.2.postman_environment.json
+++ b/postman/api.ed-fi.org-v6.2.postman_environment.json
@@ -1,28 +1,28 @@
 {
-	"id": "f82ea365-a484-4d9d-9035-9b0632511ae3",
+	"id": "02dce9ab-bac9-4d1b-a303-916c6d3d6f3b",
 	"name": "Public ODS/API 6.2 - Certification Testing",
 	"values": [
 		{
 			"key": "baseUrl",
-			"value": "https://api.ed-fi.org/v6.2/api",
+			"value": "https://certification.ed-fi.org/v6.2/api",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "resourceBaseUrl",
-			"value": "https://api.ed-fi.org/v6.2/api/data/v3",
+			"value": "https://certification.ed-fi.org/v6.2/api/data/v3",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "edFiClientId",
-			"value": "RvcohKz9zHI4",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "edFiClientSecret",
-			"value": "E1iEFusaNf81xzCxwHfbolkC",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
@@ -1192,6 +1192,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-12-24T04:13:46.444Z",
+	"_postman_exported_at": "2025-01-08T21:02:08.943Z",
 	"_postman_exported_using": "Postman/11.23.3"
 }

--- a/postman/api.ed-fi.org-v7.1.postman_environment.json
+++ b/postman/api.ed-fi.org-v7.1.postman_environment.json
@@ -1,33 +1,39 @@
 {
-	"id": "eb4829a9-0e0c-44e0-b1b6-957b89cdbdc9",
-	"name": "api.ed-fi.org/v7.1",
+	"id": "d169d88d-11d5-46b1-b543-4e8ae81a6673",
+	"name": "Certification api.ed-fi.org/v7.1",
 	"values": [
 		{
 			"key": "baseUrl",
-			"value": "https://api.ed-fi.org/v7.1/api",
+			"value": "https://certification.ed-fi.org/v7.1/api",
 			"type": "default",
 			"enabled": true
 		},
 		{
-			"key": "resourcesBaseUrl",
-			"value": "{{baseUrl}}/data/v3",
+			"key": "resourceBaseUrl",
+			"value": "https://certification.ed-fi.org/v7.1/api/data/v3",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "edFiClientId",
-			"value": "RvcohKz9zHI4",
+			"value": "",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "edFiClientSecret",
-			"value": "E1iEFusaNf81xzCxwHfbolkC",
+			"value": "",
 			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "certToken",
+			"value": "",
+			"type": "any",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-03-11T20:45:53.560Z",
-	"_postman_exported_using": "Postman/10.24.1"
+	"_postman_exported_at": "2025-01-08T21:02:32.325Z",
+	"_postman_exported_using": "Postman/11.23.3"
 }


### PR DESCRIPTION
Updated the api path for 6.1, 6.2, 7.1 versions, and removed the values of keys, thus vendors have to input their own keys.