### PR TITLE
[CERT-213] fix: user manual link updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ their own testing.
 
 If you are a SIS vendor tester using the Bruno app (GUI), please refer to the end-user manual:
 
-- [Ed‑Fi SIS Certification — How to Use (Bruno GUI)](bruno/SIS/README-User-Manual.md)
+- [Ed‑Fi SIS Certification — How to Use (Bruno GUI)](bruno/README-User-Manual.md)
 
 This manual provides version-agnostic setup, `.env` credentials, environment selection, and step-by-step scenario execution guidance.
 


### PR DESCRIPTION
This pull request updates a documentation link in the `README.md` file to ensure users are directed to the correct end-user manual.

* Documentation update:
  * Changed the link for the Bruno GUI end-user manual from `bruno/SIS/README-User-Manual.md` to `bruno/README-User-Manual.md` to point to the correct file location.